### PR TITLE
Add devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/vscode/devcontainers/dotnetcore:0-5.0
+
+# Adding libdl.so deps
+RUN apt-get update && apt-get install -y \
+  libc6-dev
+
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
+  && mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
+  && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list
+
+RUN apt-get update && apt-get install -y \
+  azure-functions-core-tools-3

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "name": "Azure function",
+    "build": {
+		"dockerfile": "Dockerfile"
+    },
+    "extensions": [
+        "ms-dotnettools.csharp"
+    ],
+    "forwardPorts": [7071],
+    "remoteUser": "vscode"
+}

--- a/README.md
+++ b/README.md
@@ -16,3 +16,10 @@ func host start --verbose
 The debugger will try to attach to your vs instance.
 ```
 
+### How to run in a devcontainer:
+
+- Open vscode
+- Install the `Remote - Container` extension
+- Re-open the directory in a container `Remote - Containers: Open folder in Container`
+
+Now you can execute the same commands as in How to run


### PR DESCRIPTION
Add the possibility to run the project in a devcontainer.
The container is based on .NET 5.0 with the addition of the azure-functions-core-tools